### PR TITLE
fix: make pyright complete imports

### DIFF
--- a/dot_config/nvim-rover/lua/rover/plugins/lspconfig.lua
+++ b/dot_config/nvim-rover/lua/rover/plugins/lspconfig.lua
@@ -86,7 +86,15 @@ return {
 
       -- Language Servers
       local servers = {
-        pyright = {},
+        pyright = {
+          settings = {
+            python = {
+              analysis = {
+                extraPaths = { '/workspaces/web/venv/lib/python3.11/site-packages', '/workspaces/web/src/aplaceforrover' },
+              },
+            },
+          },
+        },
         ts_ls = {},
         lua_ls = {
           settings = {


### PR DESCRIPTION
This should fix the errors around imports not being found! Navigate to just about any Python file before and after changes to notice the difference.

I used `src/aplaceforrover/facilities/api/views.py`